### PR TITLE
Remove numbers from list

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,9 @@
   <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data: blob:">
   <title>Zedexi v1.7</title>
   <style>
+    .sc-monitor-row-index {
+      display: none;
+    }
     body {
       color: #ffffff;
       font-family: sans-serif;


### PR DESCRIPTION
Removes the numbers from the list, since they seem to have no use and are only there because that's how Scratch lists work.